### PR TITLE
Fixes a linking error when libuv and mariadb link to system versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,5 +55,5 @@ if (WIN32)
 endif()
 
 add_executable(MasterServer ${SOURCES})
-target_link_libraries(MasterServer MDK)
+target_link_libraries(MasterServer MDK ${CMAKE_DL_LIBS})
 #set_target_properties(MasterServer PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")


### PR DESCRIPTION
Fixes a linking issue that was exposed by allowing the mdk to link against the system provided libuv and libmariadb.